### PR TITLE
Panel placed below game

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -23,10 +23,7 @@ canvas {
 
 #control {
   background: white;
-  position: fixed;
-  top: 0;
-  right: 0;
-  margin: 1em 1em 0 0;
+  margin: 10px;
   padding: 2em 0;
   -moz-box-shadow: 0 2px 5px 2px rgba(0,0,0,0.15);
   -webkit-box-shadow: 0 2px 5px 2px rgba(0,0,0,0.15);
@@ -38,14 +35,14 @@ button {
   color: #FFF;
   margin: 2em 0 0 0;
   background: #FF3F3F;
-  padding: 0.25em 1.5em;
+  padding: 0.5em 1.5em;
   border-radius: 2px;
   border: none;
   box-shadow: none;
+  cursor: pointer;
 }
 
 table {
-  margin-top: 3em;
   box-sizing: border-box;
   width: 15em;
 }
@@ -77,4 +74,30 @@ tr {
 
 table, #control {
   border-radius: 4px;
+}
+
+.col-third {
+  padding: 0 15px;
+}
+
+@media screen and (min-width: 768px) {
+  .col-third {
+    float: left;
+    width: 33.3%;
+  }
+}
+
+@media screen and (max-width: 769px) {
+  .col-third {
+    width: 100%;
+    padding-top: 15px;
+  }
+
+  .col-third:first-child {
+    padding-top: 0;
+  }
+
+  .col-third tbody td:first-child {
+    text-align: right;
+  }
 }

--- a/index.html
+++ b/index.html
@@ -20,11 +20,17 @@
     <canvas width=500 height=500 id='canvas' onmousemove="inspectCreature(event);"></canvas>
 
     <div id="control">
-      <div id="game-turn">Turn: 0</div>
-      <div id="max-time">Max turns: 0</div>
-      <div id="avg-size">Average Size: 0</div>
+      <table class="col-third">
+        <thead>
+          <tr><td>Games</td></tr>
+        </thead>
+        <tbody>
+          <tr><td>Turn</td><td id="game-turn">0</td></tr>
+          <tr><td>Most turns</td><td id="max-time">0</td></tr>
+        </tbody>
+      </table>
 
-      <table>
+      <table class="col-third">
         <thead>
           <tr><td>Creatures</td></tr>
         </thead>
@@ -32,10 +38,11 @@
           <tr><td>Alive</td><td id="alive"></td></tr>
           <tr><td>Dead</td><td id="dead"></td></tr>
           <tr><td>Total</td><td id="creature-count"></td></tr>
+          <tr><td>Average Size</td><td id="avg-size">0</td></tr>
         </tbody>
       </table>
 
-      <table>
+      <table class="col-third">
         <thead>
           <tr><td>Most Successful Colors</td></tr>
         </thead>
@@ -48,6 +55,6 @@
         </tbody>
       </table>
       <button id="reset">Reset</button>
-    </div><!-- control -->
+    </div>
   </body>
 </html>

--- a/js/dom_adapter.js
+++ b/js/dom_adapter.js
@@ -13,7 +13,7 @@ var DomAdapter = function() {
 
 DomAdapter.prototype = {
     updateTurnCounter: function(turns) {
-        this.turnCounter.textContent = "Turn: " + GAME.turns;
+        this.turnCounter.textContent = GAME.turns;
     },
     updateCreatureCount: function(count) {
         this.creatureCounter.textContent = count;
@@ -25,7 +25,7 @@ DomAdapter.prototype = {
         this.deadCounter.textContent = dead;
     },
     updateAvgSizeIndicator: function(avgSize) {
-        this.avgSizeIndicator.textContent = "Average Size: " + avgSize.toFixed(2);
+        this.avgSizeIndicator.textContent = avgSize.toFixed(2);
     },
     updateTopSpeciesList: function(topSpecies) {
         for (var x = 1; x < 6; x++) {

--- a/js/game.js
+++ b/js/game.js
@@ -61,7 +61,7 @@ var GAME = {
         // Update max turns if necessary
         if (GAME.turns > GAME.max_turns) {
             GAME.max_turns = GAME.turns;
-            document.getElementById("max-time").textContent = "Max turns: " + GAME.max_turns;
+            document.getElementById("max-time").textContent = GAME.max_turns;
         }
 
         // Create new creatures, restart game timer


### PR DESCRIPTION
The panel now responds to changing screens sizes. For screens smaller
than 768px across, the panel will consist of a column of tables. For
screens larger than 768px, the panel will be a horizonal bar, consisting
of three columns, evenly spaced.

The stats at the top of the panel that were not in any table have now
been moved to a "Games" table. The average size was moved to "Creatures," since
it pertained to creatures.
